### PR TITLE
Unsafe use of target blank vulnerability fix (powered by Mobb)

### DIFF
--- a/web_server/public/javascripts/cert_graph.js
+++ b/web_server/public/javascripts/cert_graph.js
@@ -835,7 +835,7 @@ function createDocs(obj) {
         }
     } else {
         if (obj.status === 'Resolves') {
-            returnHTML += 'Status: <a href="/domain?search=' + obj.id + '" target="_blank">' + obj.status + '</a><br/>';
+            returnHTML += 'Status: <a href="/domain?search=' + obj.id + '" rel="noopener noreferrer" target="_blank">' + obj.status + '</a><br/>';
         } else {
             returnHTML += 'Status: ' + obj.status + '<br/>';
         }


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Unsafe use of target blank** issue reported by **Checkmarx**.

## Issue description
Unsafe Target Blank occurs when developers use the target='_blank' attribute without the rel='noopener' attribute in anchor tags. This can lead to security vulnerabilities such as tabnabbing or reverse tabnabbing, allowing attackers to hijack user sessions or perform phishing attacks.
 
## Fix instructions
Ensure that anchor tags with target='_blank' attribute include the rel='noopener' attribute to prevent potential security vulnerabilities. This prevents the newly opened page from accessing the window.opener property, mitigating the risk of tabnabbing or reverse tabnabbing attacks.


[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/68b58b64-9153-4d85-8ced-7ffbce20018b/project/78e15695-e834-4e4c-9355-cde90b9410fd/report/ad49c87e-1cb0-4c74-ab59-a5faca647d37/fix/409731a0-56db-4869-bde1-a0f487f92935)
